### PR TITLE
A bug and naming fix

### DIFF
--- a/firmware/src/cli.c
+++ b/firmware/src/cli.c
@@ -174,6 +174,9 @@ void cli_run()
     if (c == 0) {
         return;
     }
+    if (!isprint(c) && c != '\b' && c != '\n' && c != '\r') {
+        return;
+    }
 
     if (c == '\b' || c == 127) { // both backspace and delete
         if (cmd_len > 0) {
@@ -182,9 +185,7 @@ void cli_run()
         }
         return;
     }
-
     if ((c != '\n') && (c != '\r')) {
-
         if (cmd_len < sizeof(cmd_buf) - 2) {
             cmd_buf[cmd_len] = c;
             printf("%c", c);

--- a/firmware/src/usb_descriptors.c
+++ b/firmware/src/usb_descriptors.c
@@ -149,7 +149,7 @@ static const char *string_desc_arr[] = {
     "I/O CONTROL BD;15257;01;90;1831;6679A;00;GOUT=14_ADIN=8,E_ROTIN=4_COININ=2_SWIN=2,E_UQ1=41,6;",
     "Geki Pico NKRO",
     "Geki Pico CLI",
-    "Mai Pico AIME Port",
+    "Geki Pico AIME Port",
 };
 
 // Invoked when received GET STRING DESCRIPTOR request


### PR DESCRIPTION
Fixed the issue that illegal characters were not filtered in the firmware, which caused the web serial port debugging to fail to input characters.
Change the aime port's descriptor.